### PR TITLE
ユーザーの削除が行えない問題を修正

### DIFF
--- a/laravel/app/Http/Controllers/Api/UserController.php
+++ b/laravel/app/Http/Controllers/Api/UserController.php
@@ -63,7 +63,7 @@ class UserController extends Controller
     public function destroy(User $user)
     {
         $requesterId = Auth::id();
-        if ($requesterId !== 1) {
+        if ($requesterId !== $user->getAuthIdentifier()) {
             return response()->json('error', 403);
         }
         $user->delete();

--- a/laravel/app/Http/Middleware/VerifyCsrfToken.php
+++ b/laravel/app/Http/Middleware/VerifyCsrfToken.php
@@ -12,6 +12,6 @@ class VerifyCsrfToken extends Middleware
      * @var array<int, string>
      */
     protected $except = [
-        //
+        'api/users/*'
     ];
 }


### PR DESCRIPTION
## 修正内容

- ユーザーIDが1でないとユーザーの削除が行えなかったため、自分自身のユーザーであれば削除が可能にしました
- /api/users/${user id}へDELETEリクエストを送信した際にCSRF周りでエラーが発生したためCSRFトークンの検証を無効化しました

## 修正概要

`UserController.php`にて`$requesterId !== 1`という比較がされていましたが、これではAdminユーザーのみがtrueとなり、自分自身のアカウントの削除を行うことができなくなっていました。そのため、`$requesterId !== $user->getAuthIdentifier()`に変更し、自分自身のアカウントであれば削除ができるように修正しました。

また、`/api/users/${user id}`へ`DELETE`リクエストを送信した際に、CSRF トークンの検証が正常に行われていることによりCSRFを行うことができなくなっていました。そのため、`VerifyCsrfToken.php`に該当エンドポイントを検証の対象外とするように記載しました。

## その他

この修正により、CSRFを行うことができるようになりました。

## 謝辞

東京MCのAトラックの講義ありがとうございました。とても楽しかったです。